### PR TITLE
Fix mcmod.info file not being valid json

### DIFF
--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -11,6 +11,6 @@
   "credits": "The Forge and FML guys",
   "logoFile": "",
   "screenshots": [],
-  "dependencies": [JEI]
+  "dependencies": ["JEI"]
 }
 ]


### PR DESCRIPTION
The current mcmod.info file is not valid json, this causes tools which parse the .jar file to pull its information to crash or be unable to return the data.